### PR TITLE
Use SPDX identifier in license field of META.info

### DIFF
--- a/META.info
+++ b/META.info
@@ -1,6 +1,7 @@
 {
     "perl"        : "6.*",
     "name"        : "JSON::JWT",
+    "license"     : "MIT",
     "version"     : "1.0",
     "author"      : "github:retupmoca",
     "description" : "JWT Signing and Verifying using openssl",


### PR DESCRIPTION
Use the standardized identifier for the license field.
For more details see https://design.perl6.org/S22.html#license